### PR TITLE
feat:DataStore 추가 - 임시

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -67,4 +67,5 @@ dependencies {
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+    implementation("androidx.datastore:datastore-preferences:1.0.0")
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <application
+        android:name=".DataStoreApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/com/example/mapin/DataStoreApplication.kt
+++ b/app/src/main/java/com/example/mapin/DataStoreApplication.kt
@@ -1,0 +1,20 @@
+package com.example.mapin
+
+import android.app.Application
+
+class DataStoreApplication:Application() {
+    private lateinit var dataStore : DataStoreModule
+
+    companion object {
+        private lateinit var dataStoreApplication: DataStoreApplication
+        fun getInstance() : DataStoreApplication = dataStoreApplication
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        dataStoreApplication = this
+        dataStore = DataStoreModule(this)
+    }
+
+    fun getDataStore() : DataStoreModule = dataStore
+}

--- a/app/src/main/java/com/example/mapin/DataStoreModule.kt
+++ b/app/src/main/java/com/example/mapin/DataStoreModule.kt
@@ -1,0 +1,39 @@
+package com.example.mapin
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
+import java.io.IOException
+
+class DataStoreModule(private val context : Context) {
+    private val Context.dataStore by
+    preferencesDataStore(name = "dataStore")
+
+    private val tokenKey = stringPreferencesKey("TOKEN_KEY")
+
+
+    val token : Flow<String> = context.dataStore.data
+        .catch { exception ->
+            if (exception is IOException) {
+                emit(emptyPreferences())
+            } else {
+                throw exception
+            }
+        }
+        .map {preferences ->
+            preferences[tokenKey] ?: ""
+        }
+
+    suspend fun setToken(token : String){
+        context.dataStore.edit { preferences ->
+            preferences[tokenKey] = token
+        }
+    }
+
+
+}

--- a/app/src/main/java/com/example/mapin/network/model/SearchLocationResponse.kt
+++ b/app/src/main/java/com/example/mapin/network/model/SearchLocationResponse.kt
@@ -1,0 +1,9 @@
+package com.example.mapin.network.model
+
+data class SearchLocationResponse(
+    val id: Int,
+    val title: String,
+    val createdAt: String,
+    val imageUrl: String,
+    val dong: String,
+)

--- a/app/src/main/java/com/example/mapin/network/service/SearchLocationService.kt
+++ b/app/src/main/java/com/example/mapin/network/service/SearchLocationService.kt
@@ -1,0 +1,47 @@
+package com.example.mapin.network.service
+
+
+import com.example.mapin.network.model.SearchLocationResponse
+import com.google.gson.GsonBuilder
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Call
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import retrofit2.http.GET
+import retrofit2.http.Header
+import retrofit2.http.Headers
+import retrofit2.http.Path
+import retrofit2.http.Query
+
+interface SearchLocationService {
+
+    @GET("/search/dong/{dong_name}")
+    fun search(
+        @Header("Authorization") authorization: String,
+        @Query("dong_name") dong_name: String
+    ): Call<List<SearchLocationResponse>>
+
+
+    companion object{
+        private const val BASE_URL = "http://hohoseung.shop/"
+
+        private val gson =
+            GsonBuilder()
+                .setLenient()
+                .create()
+        val interceptor = HttpLoggingInterceptor().apply {
+            level = HttpLoggingInterceptor.Level.BODY
+        }
+        val client = OkHttpClient.Builder().addInterceptor(interceptor).build()
+
+        fun create() : SearchLocationService {
+            return Retrofit.Builder()
+                .baseUrl(BASE_URL)
+                .client(client)
+                .addConverterFactory(GsonConverterFactory.create(gson))
+                .build()
+                .create(SearchLocationService::class.java)
+        }
+    }
+}


### PR DESCRIPTION
- 카카오앱 로그인 시에만 서버에 로그인하는 기능 수정 -> 카카오앱 없이 계정 로그인으로도 가능
- 임시 DataStore 사용(token 저장) -> 그냥 임시로 Coroutine 막 때려박아서 사용했움.. Api 테스트 다 끝나면 다듬는게 나을듯
- 지역별 검색 기능 